### PR TITLE
fix-up road labels (don't label ferry)

### DIFF
--- a/halloween.yaml
+++ b/halloween.yaml
@@ -345,7 +345,7 @@ layers:
         filter: { $zoom: { min: 10 } }
         draw:
             polygons:
-                order: 4
+                order: 5
                 color: '#999'
         extruded:
             filter: { $zoom: { min: 10 } }
@@ -355,17 +355,11 @@ layers:
                     extrude: function () { return feature.height > 0 || $zoom >= 16; }
     roads:
         data: { source: osm, layer: roads }
-        filter: { not: { highway: service, kind: [rail, ferry] } }
-        draw:
-            flatlines:
-                order: 3
-                color: [0.83, 0.83, 0.83]
-                width: function () { return Math.log($zoom); }
-    roads:
-        data: { source: osm }
+        filter: { not: { kind: [rail, ferry] } }
         properties: { width: 3 }
         draw:
             text:
+                order: 6
                 text_source: |
                     function () {
                         var name = feature.name;
@@ -484,6 +478,6 @@ layers:
                     fill: white
                     typeface: 100 11px Helvetica
             lines:
-                order: 2
+                order: 4
                 color: '#777'
                 width: 5


### PR DESCRIPTION
- don't show labels for ferry, rail lines
- remove duplicate roads layer
- reorder roads so lines are below buildings but labels are top
